### PR TITLE
Fix multiple memory leaks.

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -30,6 +30,8 @@ endif
 
 ifeq ($(DEBUG),1)
 CFLAGS+=	-Og -DDEBUG -fno-omit-frame-pointer
+CFLAGS+=	-fsanitize=address
+LDFLAGS+=	-fsanitize=address
 else
 CFLAGS+=	-DNDEBUG
 endif

--- a/src/nv_impl.h
+++ b/src/nv_impl.h
@@ -105,6 +105,7 @@ bool nvlist_move_nvpair(nvlist_t *nvl, nvpair_t *nvp);
 
 void nvlist_set_parent(nvlist_t *nvl, nvpair_t *parent);
 void nvlist_set_array_next(nvlist_t *nvl, nvpair_t *ele);
+nvpair_t *nvlist_get_array_next_nvpair(nvlist_t *nvl);
 
 const nvpair_t *nvlist_get_nvpair(const nvlist_t *nvl, const char *name);
 

--- a/src/nvlist.c
+++ b/src/nvlist.c
@@ -245,6 +245,13 @@ nvlist_set_array_next(nvlist_t *nvl, nvpair_t *ele)
 	nvl->nvl_array_next = ele;
 }
 
+nvpair_t *
+nvlist_get_array_next_nvpair(nvlist_t *nvl)
+{
+
+	return nvl->nvl_array_next;
+}
+
 bool
 nvlist_in_array(const nvlist_t *nvl)
 {

--- a/src/nvpair.c
+++ b/src/nvpair.c
@@ -228,8 +228,16 @@ nvpair_remove_nvlist_array(nvpair_t *nvp)
 	nvlarray = __DECONST(nvlist_t **,
 	    nvpair_get_nvlist_array(nvp, &count));
 	for (i = 0; i < count; i++) {
-		nvlist_set_array_next(nvlarray[i], NULL);
-		nvlist_set_parent(nvlarray[i], NULL);
+		nvlist_t *nvl;
+		nvpair_t *nnvp;
+
+		nvl = nvlarray[i];
+		nnvp = nvlist_get_array_next_nvpair(nvl);
+		if (nnvp != NULL) {
+			nvpair_free_structure(nnvp);
+		}
+		nvlist_set_array_next(nvl, NULL);
+		nvlist_set_parent(nvl, NULL);
 	}
 }
 
@@ -1192,8 +1200,7 @@ nvpair_create_stringv(const char *name, const char *valuefmt, va_list valueap)
 	if (len < 0)
 		return (NULL);
 	nvp = nvpair_create_string(name, str);
-	if (nvp == NULL)
-		nv_free(str);
+	nv_free(str);
 	return (nvp);
 }
 
@@ -2089,6 +2096,7 @@ nvpair_free(nvpair_t *nvp)
 	case NV_TYPE_STRING_ARRAY:
 		for (i = 0; i < nvp->nvp_nitems; i++)
 			nv_free(((char **)(intptr_t)nvp->nvp_data)[i]);
+		nv_free(((void *)(intptr_t)nvp->nvp_data));
 		break;
 	}
 	nv_free(nvp);

--- a/src/tests/nvlist_send_recv_test.c
+++ b/src/tests/nvlist_send_recv_test.c
@@ -305,6 +305,8 @@ parent(int sock)
 
 	name = nvlist_next(nvl, &type, &cookie);
 	CHECK(name == NULL);
+
+	nvlist_destroy(nvl);
 }
 
 int


### PR DESCRIPTION
- nvpair_free: free the data array for NV_TYPE_STRING_ARRAY case.
  Affects the nvlist_*_string_array() family of functions.
- nvpair_create_stringv: free the temporary string; this fix affects
  nvlist_add_stringf() and nvlist_add_stringv().
- nvpair_remove_nvlist_array (NV_TYPE_NVLIST_ARRAY case): free the chain
  of nvpairs (as resetting it prevents nvlist_destroy() from freeing it).
  Note: freeing the chain in nvlist_destroy() is not sufficient, because
  it would still leak through nvlist_take_nvlist_array().  This affects
  all nvlist_*_nvlist_array() users.
- Enable clang/gcc ASAN for the debug build.  It will now automatically
  try to detect memory leaks and other bugs, as part of running the tests.